### PR TITLE
Added build instructions for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,14 @@ Features:
 - Qt 6.4.2
 
 ### Ubuntu 24
-```
+```shell
 sudo apt install -y cmake g++ libssl-dev qt6-base-dev libgtest-dev build-essential 
+```
+
+### MacOS
+Install [homebrew](https://brew.sh/) beforehand.
+```shell
+brew install qt@6 openssl@3 googletest
 ```
 
 ### Build

--- a/src/tagdialog.h
+++ b/src/tagdialog.h
@@ -17,7 +17,7 @@ class TagDialog : public QDialog
 
 public:
     ///A list of valid symbols that can be chosen for a tag
-    constexpr static const std::string symbols[]{
+    constexpr static const char *symbols[]{
             "❓",
             "❌",
             "⭕",


### PR DESCRIPTION
* Added build instructions for macOS to readme
* Used `char *` instead of `std::string` to circumvent [known clang bug](https://github.com/rust-lang/rust-bindgen/issues/1948)